### PR TITLE
Add support for SMCCC

### DIFF
--- a/aarch64-esr-web/www/index.html
+++ b/aarch64-esr-web/www/index.html
@@ -26,5 +26,7 @@
     <table id="result_table"></table>
     <p id="error"></p>
     <p><a href="midr.html">MIDR decoder</a></p>
+    <p><a href="smccc.html">SMCCC decoder</a></p>
+
   </body>
 </html>

--- a/aarch64-esr-web/www/index.js
+++ b/aarch64-esr-web/www/index.js
@@ -45,3 +45,17 @@ if (midr != null) {
     wasm.decode_midr(midr.value);
   }
 }
+const smccc = document.getElementById("smccc");
+if (smccc != null) {
+  smccc.oninput = () => {
+    if (smccc.value.length > 0) {
+      wasm.decode_smccc(smccc.value);
+    }
+    window.location.hash = smccc.value;
+  };
+
+  if (window.location.hash) {
+    smccc.value = window.location.hash.substring(1);
+    wasm.decode_smccc(smccc.value);
+  }
+}

--- a/aarch64-esr-web/www/smccc.html
+++ b/aarch64-esr-web/www/smccc.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>AArch64 MIDR decoder</title>
+    <title>SMCCC decoder</title>
     <style type="text/css">
       table { border-collapse: collapse; }
       td { border: 1px solid black; }
@@ -15,17 +15,17 @@
   <body>
     <noscript>This page contains webassembly and JavaScript content, please enable JavaScript in your browser.</noscript>
     <script src="./bootstrap.js"></script>
-    <h1>AArch64 MIDR decoder</h1>
+    <h1>Arm SMCCC decoder</h1>
     <p><a href="https://github.com/google/aarch64-esr-decoder">Source and command-line version</a></p>
     <form>
       <p>
-        <label for="midr">MIDR:</label>
-        <input type="text" id="midr" autofocus="true"/>
+        <label for="smccc">Function ID:</label>
+        <input type="text" id="smccc" autofocus="true"/>
       </p>
     </form>
     <table id="result_table"></table>
     <p id="error"></p>
     <p><a href="/">ESR decoder</a></p>
-    <p><a href="smccc.html">SMCCC decoder</a></p>
+    <p><a href="midr.html">MIDR decoder</a></p>
   </body>
 </html>

--- a/aarch64-esr-web/www/webpack.config.js
+++ b/aarch64-esr-web/www/webpack.config.js
@@ -8,5 +8,5 @@ module.exports = {
     filename: "bootstrap.js",
   },
   mode: "development",
-  plugins: [new CopyWebpackPlugin(["index.html", "midr.html"])],
+  plugins: [new CopyWebpackPlugin(["index.html", "midr.html", "smccc.html"])],
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,12 @@
 
 mod esr;
 mod midr;
+mod smccc;
 
 use bit_field::BitField;
 pub use esr::decode;
 pub use midr::decode_midr;
+pub use smccc::decode_smccc;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::num::ParseIntError;
 use thiserror::Error;

--- a/src/smccc.rs
+++ b/src/smccc.rs
@@ -1,0 +1,142 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Decoder for SMC Calling Convention ARM DEN 0028E v1.4
+
+mod arm;
+mod common;
+mod hyp;
+mod secure;
+mod tapp;
+
+use arm::decode_arm_service;
+use common::decode_common_service;
+use common::describe_general32_queries;
+use common::reserved_fids;
+use common::smccc_general32_queries;
+use hyp::decode_hyp_service;
+use secure::decode_secure_service;
+use tapp::decode_tapp_service;
+
+use super::{DecodeError, FieldInfo};
+
+/// Decodes the function id of SMCCC(ARM DEN 0028E v1.4), or returns an error if it is not valid.
+pub fn decode_smccc(smccc: u64) -> Result<Vec<FieldInfo>, DecodeError> {
+    let call_type = FieldInfo::get(
+        smccc,
+        "Call Type",
+        Some("Fast Call[1] Yielding Call[0]"),
+        31,
+        32,
+    )
+    .describe(describe_call)?;
+
+    let result = if call_type.value == 1 {
+        parse_fastcall(smccc)?
+    } else {
+        parse_yieldcall(smccc)?
+    };
+
+    Ok([vec![call_type], result].concat())
+}
+
+pub fn parse_fastcall(smccc: u64) -> Result<Vec<FieldInfo>, DecodeError> {
+    let call_convention = FieldInfo::get(
+        smccc,
+        "Call Convention",
+        Some("SMC32/HV32[0] SMC64/HVC64[1]"),
+        30,
+        31,
+    )
+    .describe(describe_convention)?;
+    let service_call =
+        FieldInfo::get(smccc, "Service Call", None, 24, 30).describe(describe_service)?;
+
+    let mbz = FieldInfo::get(
+        smccc,
+        "MBZ",
+        Some("Some legacy Armv7 set this to 1"),
+        17,
+        24,
+    );
+    let sve = FieldInfo::get(
+        smccc,
+        "SVE live state",
+        Some("No live state[1] From SMCCCv1.3, before SMCCCv1.3 MBZ"),
+        16,
+        17,
+    );
+
+    let function_number = match service_call.value {
+        0x00 => decode_arm_service(smccc, call_convention.value)?,
+        0x04 => decode_secure_service(smccc, call_convention.value)?,
+        0x05 => decode_hyp_service(smccc, call_convention.value)?,
+        0x30..=0x31 => decode_tapp_service(smccc, call_convention.value)?,
+        _ => decode_common_service(smccc, call_convention.value)?,
+    };
+
+    Ok(vec![
+        call_convention,
+        service_call,
+        mbz,
+        sve,
+        function_number,
+    ])
+}
+pub fn parse_yieldcall(smccc: u64) -> Result<Vec<FieldInfo>, DecodeError> {
+    let yield_type =
+        FieldInfo::get(smccc, "Service Type", None, 0, 31).describe(describe_yield_service)?;
+    Ok(vec![yield_type])
+}
+
+fn describe_yield_service(service: u64) -> Result<&'static str, DecodeError> {
+    Ok(match service {
+        0x00000000..=0x0100FFFF => {
+            "Reserved for existing APIs (in use by the existing Armv7 devices)"
+        }
+        0x02000000..=0x1FFFFFFF => "Trusted OS Yielding Calls",
+        0x20000000..=0x7FFFFFFF => "Reserved for future expansion of Trusted OS Yielding Calls",
+        _ => "Unknown",
+    })
+}
+
+fn describe_call(call: u64) -> Result<&'static str, DecodeError> {
+    Ok(match call {
+        0x00 => "Yielding Call",
+        0x01 => "Fast Call",
+        _ => "Unknown",
+    })
+}
+fn describe_convention(conv: u64) -> Result<&'static str, DecodeError> {
+    Ok(match conv {
+        0x00 => "SMC32/HVC32",
+        0x01 => "SMC64/HVC64",
+        _ => "Unknown",
+    })
+}
+fn describe_service(service: u64) -> Result<&'static str, DecodeError> {
+    Ok(match service {
+        0x00 => "Arm Architecture Call",
+        0x01 => "CPU Service Call",
+        0x02 => "SiP Service Call",
+        0x03 => "OEM Service Call",
+        0x04 => "Standard Secure Service Call",
+        0x05 => "Standard Hypervisor Service Call",
+        0x06 => "Vendor Specific Hypervisor Service Call",
+        0x07..=0x2F => "Reserved for future use",
+        0x30..=0x31 => "Trusted Application Call",
+        0x32..=0x3F => "Trusted OS Call",
+        _ => "Unknown",
+    })
+}

--- a/src/smccc/arm.rs
+++ b/src/smccc/arm.rs
@@ -1,0 +1,41 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{reserved_fids, DecodeError, FieldInfo};
+
+pub fn decode_arm_service(smccc: u64, conv: u64) -> Result<FieldInfo, DecodeError> {
+    if conv == 0 {
+        FieldInfo::get(smccc, "Function Number", None, 0, 16).describe(describe_arm32_service)
+    } else {
+        FieldInfo::get(smccc, "Function Number", None, 0, 16).describe(describe_arm64_service)
+    }
+}
+
+fn describe_arm32_service(service: u64) -> Result<&'static str, DecodeError> {
+    Ok(match service {
+        0x0000 => "SMCCC_VERSION",
+        0x0001 => "SMCCC_ARCH_FEATURES",
+        0x0002 => "SMCCC_ARCH_SOC_ID",
+        0x3FFF => "SMCCC_ARCH_WORKAROUND_3",
+        0x7FFF => "SMCCC_ARCH_WORKAROUND_2",
+        0x8000 => "SMCCC_ARCH_WORKAROUND_1",
+        0xFF00 => "Call Count Query, deprecated from SMCCCv1.2",
+        0xFF01 => "Call UUID Query, deprecated from SMCCCv1.2",
+        0xFF03 => "Revision Query, deprecated from SMCCCv1.2",
+        _ => reserved_fids(service),
+    })
+}
+fn describe_arm64_service(service: u64) -> Result<&'static str, DecodeError> {
+    Ok(reserved_fids(service))
+}

--- a/src/smccc/common.rs
+++ b/src/smccc/common.rs
@@ -1,0 +1,45 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{DecodeError, FieldInfo};
+
+pub fn decode_common_service(smccc: u64, conv: u64) -> Result<FieldInfo, DecodeError> {
+    if conv == 0 {
+        FieldInfo::get(smccc, "Function Number", None, 0, 16).describe(describe_general32_queries)
+    } else {
+        FieldInfo::get(smccc, "Function Number", None, 0, 16).describe(describe_general64_queries)
+    }
+}
+
+pub fn reserved_fids(service: u64) -> &'static str {
+    match service {
+        0xFF00..=0xFFFF => "Reserved for future expansion",
+        _ => "",
+    }
+}
+
+pub fn smccc_general32_queries(service: u64) -> &'static str {
+    match service {
+        0xFF00 => "Call Count Query, deprecated from SMCCCv1.2",
+        0xFF01 => "Call UUID Query",
+        0xFF03 => "Revision Query",
+        _ => reserved_fids(service),
+    }
+}
+pub fn describe_general32_queries(service: u64) -> Result<&'static str, DecodeError> {
+    Ok(smccc_general32_queries(service))
+}
+pub fn describe_general64_queries(service: u64) -> Result<&'static str, DecodeError> {
+    Ok(reserved_fids(service))
+}

--- a/src/smccc/hyp.rs
+++ b/src/smccc/hyp.rs
@@ -1,0 +1,30 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{describe_general32_queries, DecodeError, FieldInfo};
+
+pub fn decode_hyp_service(smccc: u64, conv: u64) -> Result<FieldInfo, DecodeError> {
+    if conv == 0 {
+        FieldInfo::get(smccc, "Function Number", None, 0, 16).describe(describe_general32_queries)
+    } else {
+        FieldInfo::get(smccc, "Function Number", None, 0, 16).describe(describe_hyp64_service)
+    }
+}
+
+fn describe_hyp64_service(service: u64) -> Result<&'static str, DecodeError> {
+    Ok(match service {
+        0x20..=0x3F => "PV Time 64-bit calls",
+        _ => "",
+    })
+}

--- a/src/smccc/secure.rs
+++ b/src/smccc/secure.rs
@@ -1,0 +1,46 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{smccc_general32_queries, DecodeError, FieldInfo};
+
+pub fn decode_secure_service(smccc: u64, conv: u64) -> Result<FieldInfo, DecodeError> {
+    if conv == 0 {
+        FieldInfo::get(smccc, "Function Number", None, 0, 16).describe(describe_secure32_service)
+    } else {
+        FieldInfo::get(smccc, "Function Number", None, 0, 16).describe(describe_secure64_service)
+    }
+}
+
+fn secure_service(service: u64) -> &'static str {
+    match service {
+        0x000..=0x01F => "PSCI Call (Power Secure Control Interface)",
+        0x020..=0x03F => "SDEI Call (Software Delegated Exception Interface)",
+        0x040..=0x04F => "MM Call (Management Mode)",
+        0x050..=0x05F => "TRNG Call",
+        0x060..=0x0EF => "FF-A Call",
+        0x0F0..=0x10F => "Errata Call",
+        0x150..=0x1CF => "CCA Call",
+        _ => "",
+    }
+}
+
+fn describe_secure32_service(service: u64) -> Result<&'static str, DecodeError> {
+    Ok(match service {
+        0x000..=0x1CF => secure_service(service),
+        _ => smccc_general32_queries(service),
+    })
+}
+fn describe_secure64_service(service: u64) -> Result<&'static str, DecodeError> {
+    Ok(secure_service(service))
+}

--- a/src/smccc/tapp.rs
+++ b/src/smccc/tapp.rs
@@ -1,0 +1,19 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{DecodeError, FieldInfo};
+
+pub fn decode_tapp_service(smccc: u64, _conv: u64) -> Result<FieldInfo, DecodeError> {
+    Ok(FieldInfo::get(smccc, "Function Number", None, 0, 16))
+}


### PR DESCRIPTION
Add new decoder for SMCCC function ID
SMCCC function ID is 32 bits, some modifications needed for aarch64-esr-web/src/lib.rs to be able to visualize 32 bit(or custom) values