### PR TITLE
web: js: trim values before passing to wasm

### DIFF
--- a/aarch64-esr-web/js/index.js
+++ b/aarch64-esr-web/js/index.js
@@ -18,45 +18,58 @@ import("../pkg").then((wasm) => {
   const esr = document.getElementById("esr");
   if (esr != null) {
     esr.oninput = () => {
-      if (esr.value.length > 0) {
-        wasm.decode_esr(esr.value);
+      const value = esr.value.trim();
+      if (value.length > 0) {
+        wasm.decode_esr(value);
       }
-      window.location.hash = esr.value;
+      window.location.hash = value;
     };
 
     if (window.location.hash) {
-      esr.value = window.location.hash.substring(1);
-      wasm.decode_esr(esr.value);
+      const value = window.location.hash.substring(1).trim();
+      esr.value = value;
+      if (value.length > 0) {
+        wasm.decode_esr(value);
+      }
     }
   }
 
   const midr = document.getElementById("midr");
   if (midr != null) {
     midr.oninput = () => {
-      if (midr.value.length > 0) {
-        wasm.decode_midr(midr.value);
+      const value = midr.value.trim();
+      if (value.length > 0) {
+        wasm.decode_midr(value);
       }
-      window.location.hash = midr.value;
+      window.location.hash = value;
     };
 
     if (window.location.hash) {
-      midr.value = window.location.hash.substring(1);
-      wasm.decode_midr(midr.value);
+      const value = window.location.hash.substring(1).trim();
+      midr.value = value;
+      if (value.length > 0) {
+        wasm.decode_midr(value);
+      }
     }
   }
 
   const smccc = document.getElementById("smccc");
   if (smccc != null) {
     smccc.oninput = () => {
-      if (smccc.value.length > 0) {
-        wasm.decode_smccc(smccc.value);
+      const value = smccc.value.trim();
+      if (value.length > 0) {
+        wasm.decode_smccc(value);
       }
-      window.location.hash = smccc.value;
+      window.location.hash = value;
     };
 
     if (window.location.hash) {
-      smccc.value = window.location.hash.substring(1);
-      wasm.decode_smccc(smccc.value);
+      const value = window.location.hash.substring(1).trim();
+      smccc.value = value;
+
+      if (value.length > 0) {
+        wasm.decode_smccc(value);
+      }
     }
   }
 });


### PR DESCRIPTION
User input values are currently directly passed to wasm as long as they are more than 0 characters long. This also means that having an ascii whitespace leads to input being invalid.

This patch introduces trimming before passing it to wasm and also before saving it in the url. So sharing the url is also safe.

Side note: I used an intermediate `value` because updating `{register}.value` makes it impossible to type any ascii whitespaces in the input box. It does sound nice but in my opinion, it feels too restrictive.

closes #239